### PR TITLE
Add exit confirmation to Linux shell script.

### DIFF
--- a/generate-factory-images-common.sh
+++ b/generate-factory-images-common.sh
@@ -180,6 +180,10 @@ fastboot -w --skip-reboot update image-$PRODUCT-$VERSION.zip
 fastboot reboot-bootloader
 sleep $SLEEPDURATION
 EOF
+cat >> tmp/$PRODUCT-$VERSION/flash-all.sh << EOF
+echo "Press Enter to exit..."
+read
+EOF
 chmod a+x tmp/$PRODUCT-$VERSION/flash-all.sh
 
 # Write flash-all.bat


### PR DESCRIPTION
One of the chatters in the IRC channel noticed that the Windows script has an exit pause and confirmation but the Linux version seems to be missing it, so I decided to try adding that using a read command.

Let me know if this works for you.