### PR TITLE
Raise minimum fastboot version to 33.0.4

### DIFF
--- a/generate-factory-images-common.sh
+++ b/generate-factory-images-common.sh
@@ -133,7 +133,7 @@ if ! command -v fastboot > /dev/null; then
   exit 1
 fi
 
-if ! [ \$("\$(which fastboot)" --version | grep "version" | cut -c18-23 | sed 's/\.//g' ) -ge 3303 ]; then
+if ! [ \$("\$(which fastboot)" --version | grep "version" | cut -c18-23 | sed 's/\.//g' ) -ge 3304 ]; then
   echo "fastboot too old; please download the latest version at https://developer.android.com/studio/releases/platform-tools.html"
   exit 1
 fi


### PR DESCRIPTION
I came across an error while flashing GrapheneOS recently (I've redacted my serial number):

```
--------------------------------------------
Bootloader Version...: cloudripper-1.0-9592577
Baseband Version.....: g5300g-221229-230210-B-9589366
Serial Number........: <redacted>
--------------------------------------------
extracting android-info.txt (0 MB) to RAM...
Checking 'product'                                 OKAY [  0.000s]
Checking 'version-bootloader'                      OKAY [  0.000s]
Checking 'version-baseband'                        OKAY [  0.000s]
fastboot: error: device requires partition vendor_kernel_boot which is not known to this version of fastboot
```

After investigation, it appears that **vendor_kernel_boot** support was only added in version 33.0.4 ([here's the commit that added this](https://android.googlesource.com/platform/system/core/+/f0fb5dde89827a51926c6c7ce59384500a2b5b95%5E!/)).

This commit should solve this issue for the future by requiring people to use fastboot 33.0.4 or above.

Note: I'm a first-time contributor and while I've read as much as I can regarding contributing, there isn't much information on the site beyond style guides and such. If I'm missing any important steps, please let me know.